### PR TITLE
feat: add inline code marks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Improvements
 
+- **Inline code blocks**: In the editor you can now find the "code" option to style your text. This is a first step before we get fully highlighted code blocks.
 - We polished the animations, they are now a smoother 🎨.
 - If you visit the login page while being already logged in, you will now be redirected automatically to the home page.
 

--- a/src/modules/editor/components/SlateEditor.tsx
+++ b/src/modules/editor/components/SlateEditor.tsx
@@ -177,6 +177,9 @@ const handleKeyDown = (
     mark = 'italic';
   } else if (event.key === 'u') {
     mark = 'underlined';
+  } else if (event.keyCode === 192) {
+    // event.keyCode 192 is '`'
+    mark = 'code';
   } else {
     return next();
   }
@@ -327,6 +330,8 @@ export const SlateEditor = ({
         return <em {...attributes}>{children}</em>;
       case 'underlined':
         return <u {...attributes}>{children}</u>;
+      case 'code':
+        return <code {...attributes}>{children}</code>;
       default:
         return next();
     }

--- a/src/modules/editor/components/SlateEditorHoverMenu.tsx
+++ b/src/modules/editor/components/SlateEditorHoverMenu.tsx
@@ -15,6 +15,7 @@ import {
   MdFormatListNumbered,
   MdFormatListBulleted,
   MdLink,
+  MdCode,
 } from 'react-icons/md';
 import { hasLinks, hasBlock, hasMark } from './utils';
 import { onClickLink, onClickBlock, onClickMark } from './SlateEditorToolbar';
@@ -129,6 +130,7 @@ export const SlateEditorHoverMenu = forwardRef(
         {renderMarkButton('bold', MdFormatBold)}
         {renderMarkButton('italic', MdFormatItalic)}
         {renderMarkButton('underlined', MdFormatUnderlined)}
+        {renderMarkButton('code', MdCode)}
         {renderBlockButton('block-quote', MdFormatQuote)}
         {renderBlockButton('heading-one', MdLooksOne)}
         {renderBlockButton('heading-two', MdLooksTwo)}

--- a/src/modules/editor/components/SlateEditorToolbar.tsx
+++ b/src/modules/editor/components/SlateEditorToolbar.tsx
@@ -27,6 +27,7 @@ import {
   MdLink,
   MdSettings,
   MdImage,
+  MdCode,
 } from 'react-icons/md';
 import { ButtonOutline } from '../../../components';
 
@@ -241,6 +242,7 @@ export const SlateEditorToolbar = ({
         {renderMarkButton('bold', MdFormatBold)}
         {renderMarkButton('italic', MdFormatItalic)}
         {renderMarkButton('underlined', MdFormatUnderlined)}
+        {renderMarkButton('code', MdCode)}
         {renderBlockButton('block-quote', MdFormatQuote)}
         {renderBlockButton('heading-one', MdLooksOne)}
         {renderBlockButton('heading-two', MdLooksTwo)}

--- a/src/modules/publicStory/components/PublicStory.tsx
+++ b/src/modules/publicStory/components/PublicStory.tsx
@@ -50,6 +50,8 @@ const rules = [
             return <em>{children}</em>;
           case 'underlined':
             return <u>{children}</u>;
+          case 'code':
+            return <code>{children}</code>;
         }
       }
     },
@@ -164,6 +166,12 @@ export const Content = styled.div`
 
   a {
     ${tw`text-pink`};
+  }
+
+  code {
+    ${tw`font-mono text-sm inline bg-grey-light px-1 rounded-sm`};
+    padding-top: 0.15rem;
+    padding-bottom: 0.15rem;
   }
 
   img {


### PR DESCRIPTION
**Inline code blocks**: In the editor you can now find the "code" option to style your text. This is a first step before we get fully highlighted code blocks.

Related to #26 