### PR TITLE
feat: use next middleware to redirect to HTTPS

### DIFF
--- a/sigle/next-env.d.ts
+++ b/sigle/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/sigle/src/pages/_app.tsx
+++ b/sigle/src/pages/_app.tsx
@@ -91,22 +91,6 @@ Router.events.on('routeChangeStart', () => NProgress.start());
 Router.events.on('routeChangeComplete', () => NProgress.done());
 Router.events.on('routeChangeError', () => NProgress.done());
 
-/**
- * Force https client side
- * Ideally it should be server side but we would lose the next.js optimisation
- */
-const ForceHTTPS = () => {
-  useEffect(() => {
-    // Only check in production to avoid redirecting localhost
-    if (sigleConfig.env === 'production' && location.protocol !== 'https:') {
-      location.replace(
-        `https:${location.href.substring(location.protocol.length)}`
-      );
-    }
-  }, []);
-
-  return <React.Fragment />;
-};
 export default class MyApp extends App {
   render() {
     const { Component, pageProps } = this.props;
@@ -151,7 +135,6 @@ export default class MyApp extends App {
           }}
         />
         <GlobalStyle />
-        <ForceHTTPS />
         <FathomTrack />
         <QueryClientProvider client={queryClient}>
           <ReactQueryDevtools initialIsOpen={false} />

--- a/sigle/src/pages/_middleware.ts
+++ b/sigle/src/pages/_middleware.ts
@@ -1,0 +1,18 @@
+import { NextFetchEvent, NextRequest, NextResponse } from 'next/server';
+
+/**
+ * The goal of this middleware is to force https server side.
+ * Fly.io does not provide this option internally.
+ */
+export function middleware(req: NextRequest, ev: NextFetchEvent) {
+  if (
+    process.env.NODE_ENV === 'production' &&
+    req.headers.get('x-forwarded-proto') !== 'https'
+  ) {
+    return NextResponse.redirect(
+      `https://${req.nextUrl.hostname}${req.nextUrl.pathname}`,
+      301
+    );
+  }
+  return NextResponse.next();
+}

--- a/sigle/src/pages/_middleware.ts
+++ b/sigle/src/pages/_middleware.ts
@@ -1,10 +1,10 @@
-import { NextFetchEvent, NextRequest, NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
 /**
  * The goal of this middleware is to force https server side.
  * Fly.io does not provide this option internally.
  */
-export function middleware(req: NextRequest, ev: NextFetchEvent) {
+export function middleware(req: NextRequest) {
   if (
     process.env.NODE_ENV === 'production' &&
     req.headers.get('x-forwarded-proto') !== 'https'


### PR DESCRIPTION
When I wrote this logic middlewares were not a thing in next.js, now we can handle properly the HTTPS redirection server-side.
The middleware is run at the edge with the fly firecracker.