### PR TITLE
feat: inline menu open slash command

### DIFF
--- a/sigle/src/icons/RoundPlus.tsx
+++ b/sigle/src/icons/RoundPlus.tsx
@@ -1,0 +1,25 @@
+import { IconProps } from '@radix-ui/react-icons/dist/types';
+
+export const RoundPlus = ({ width = 27, height = 27 }: IconProps) => (
+  <svg
+    width={width}
+    height={height}
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M13.75 8.5a.5.5 0 0 0-1 0v4.25H8.5a.5.5 0 0 0 0 1h4.25V18a.5.5 0 0 0 1 0v-4.25H18a.5.5 0 0 0 0-1h-4.25V8.5Z"
+      fill="#1A1A1A"
+    />
+    <rect
+      x={0.5}
+      y={0.5}
+      width={25.5}
+      height={25.5}
+      rx={12.75}
+      stroke="#1A1A1A"
+    />
+  </svg>
+);

--- a/sigle/src/icons/RoundPlus.tsx
+++ b/sigle/src/icons/RoundPlus.tsx
@@ -11,7 +11,7 @@ export const RoundPlus = ({ width = 27, height = 27 }: IconProps) => (
       fillRule="evenodd"
       clipRule="evenodd"
       d="M13.75 8.5a.5.5 0 0 0-1 0v4.25H8.5a.5.5 0 0 0 0 1h4.25V18a.5.5 0 0 0 1 0v-4.25H18a.5.5 0 0 0 0-1h-4.25V8.5Z"
-      fill="#1A1A1A"
+      fill="currentColor"
     />
     <rect
       x={0.5}
@@ -19,7 +19,7 @@ export const RoundPlus = ({ width = 27, height = 27 }: IconProps) => (
       width={25.5}
       height={25.5}
       rx={12.75}
-      stroke="#1A1A1A"
+      stroke="currentColor"
     />
   </svg>
 );

--- a/sigle/src/icons/index.tsx
+++ b/sigle/src/icons/index.tsx
@@ -6,3 +6,4 @@ export * from './Heading2Light';
 export * from './Heading3Light';
 export * from './ImageLight';
 export * from './QuoteLight';
+export * from './RoundPlus';

--- a/sigle/src/modules/editor/FloatingMenu.tsx
+++ b/sigle/src/modules/editor/FloatingMenu.tsx
@@ -55,7 +55,7 @@ export const FloatingMenu = ({ editor }: FloatingMenuProps) => {
         onClick={handleButtonClick}
         css={{
           display: 'flex',
-          color: '$gray8',
+          color: '$gray9',
         }}
       >
         <RoundPlus width={27} height={27} />

--- a/sigle/src/modules/editor/FloatingMenu.tsx
+++ b/sigle/src/modules/editor/FloatingMenu.tsx
@@ -1,20 +1,49 @@
-import { useState } from 'react';
 import { Editor, FloatingMenu as TipTapFloatingMenu } from '@tiptap/react';
-import { PlusCircledIcon, CrossCircledIcon } from '@radix-ui/react-icons';
 import { Box } from '../../ui';
+import { globalCss } from '../../stitches.config';
+import { RoundPlus } from '../../icons';
+
+// Tippyjs theme used by the slash command menu
+const globalStylesCustomEditor = globalCss({
+  ".tippy-box[data-theme~='sigle-editor-floating-menu']": {
+    backgroundColor: 'transparent',
+  },
+  ".tippy-box[data-theme~='sigle-editor-floating-menu'] .tippy-content": {
+    backgroundColor: 'transparent',
+    padding: 0,
+    color: '$gray8',
+  },
+});
 
 interface FloatingMenuProps {
   editor: Editor;
 }
 
 export const FloatingMenu = ({ editor }: FloatingMenuProps) => {
-  const [menuOpen, setMenuOpen] = useState(false);
+  globalStylesCustomEditor();
+
+  const handleButtonClick = () => {
+    editor
+      .chain()
+      .focus()
+      .command(({ tr }) => {
+        // manipulate the transaction
+        tr.insertText('/');
+
+        return true;
+      })
+      .run();
+  };
 
   return (
     <TipTapFloatingMenu
       editor={editor}
       pluginKey="inline-add-menu"
-      tippyOptions={{ theme: 'light-border' }}
+      tippyOptions={{
+        theme: 'sigle-editor-floating-menu',
+        placement: 'left',
+        arrow: false,
+      }}
       shouldShow={({ editor, state }) => {
         // Show only on empty blocks
         const empty = state.selection.empty;
@@ -22,18 +51,15 @@ export const FloatingMenu = ({ editor }: FloatingMenuProps) => {
         return editor.isActive('paragraph') && empty && node.content.size === 0;
       }}
     >
-      <Box css={{ position: 'absolute', top: 5, left: -46, color: '$gray11' }}>
-        {/* TODO animation */}
-        <button onClick={() => setMenuOpen(!menuOpen)}>
-          {!menuOpen ? (
-            <PlusCircledIcon width={24} height={24} />
-          ) : (
-            <CrossCircledIcon width={24} height={24} />
-          )}
-        </button>
+      <Box
+        as="button"
+        onClick={handleButtonClick}
+        css={{
+          display: 'flex',
+        }}
+      >
+        <RoundPlus width={27} height={27} />
       </Box>
-
-      {menuOpen ? <div>Heya</div> : null}
     </TipTapFloatingMenu>
   );
 };

--- a/sigle/src/modules/editor/FloatingMenu.tsx
+++ b/sigle/src/modules/editor/FloatingMenu.tsx
@@ -11,7 +11,6 @@ const globalStylesCustomEditor = globalCss({
   ".tippy-box[data-theme~='sigle-editor-floating-menu'] .tippy-content": {
     backgroundColor: 'transparent',
     padding: 0,
-    color: '$gray8',
   },
 });
 
@@ -56,6 +55,7 @@ export const FloatingMenu = ({ editor }: FloatingMenuProps) => {
         onClick={handleButtonClick}
         css={{
           display: 'flex',
+          color: '$gray8',
         }}
       >
         <RoundPlus width={27} height={27} />

--- a/sigle/src/modules/editor/FloatingMenu.tsx
+++ b/sigle/src/modules/editor/FloatingMenu.tsx
@@ -49,11 +49,6 @@ export const FloatingMenu = ({ editor }: FloatingMenuProps) => {
         const empty = state.selection.empty;
         const node = state.selection.$head.node();
         return editor.isActive('paragraph') && empty && node.content.size === 0;
-        // const nodeText = node.content.firstChild?.text;
-        // return (
-        //   editor.isActive('paragraph') &&
-        //   ((empty && node.content.size === 0) || nodeText === '/')
-        // );
       }}
     >
       <Flex as="button" onClick={handleButtonClick}>

--- a/sigle/src/modules/editor/FloatingMenu.tsx
+++ b/sigle/src/modules/editor/FloatingMenu.tsx
@@ -11,6 +11,7 @@ const globalStylesCustomEditor = globalCss({
   ".tippy-box[data-theme~='sigle-editor-floating-menu'] .tippy-content": {
     backgroundColor: 'transparent',
     padding: 0,
+    color: '$gray9',
   },
 });
 
@@ -55,7 +56,6 @@ export const FloatingMenu = ({ editor }: FloatingMenuProps) => {
         onClick={handleButtonClick}
         css={{
           display: 'flex',
-          color: '$gray9',
         }}
       >
         <RoundPlus width={27} height={27} />

--- a/sigle/src/modules/editor/FloatingMenu.tsx
+++ b/sigle/src/modules/editor/FloatingMenu.tsx
@@ -48,8 +48,12 @@ export const FloatingMenu = ({ editor }: FloatingMenuProps) => {
         // Show only on empty blocks
         const empty = state.selection.empty;
         const node = state.selection.$head.node();
-
         return editor.isActive('paragraph') && empty && node.content.size === 0;
+        // const nodeText = node.content.firstChild?.text;
+        // return (
+        //   editor.isActive('paragraph') &&
+        //   ((empty && node.content.size === 0) || nodeText === '/')
+        // );
       }}
     >
       <Flex as="button" onClick={handleButtonClick}>

--- a/sigle/src/modules/editor/FloatingMenu.tsx
+++ b/sigle/src/modules/editor/FloatingMenu.tsx
@@ -48,6 +48,7 @@ export const FloatingMenu = ({ editor }: FloatingMenuProps) => {
         // Show only on empty blocks
         const empty = state.selection.empty;
         const node = state.selection.$head.node();
+
         return editor.isActive('paragraph') && empty && node.content.size === 0;
       }}
     >

--- a/sigle/src/modules/editor/FloatingMenu.tsx
+++ b/sigle/src/modules/editor/FloatingMenu.tsx
@@ -1,5 +1,5 @@
 import { Editor, FloatingMenu as TipTapFloatingMenu } from '@tiptap/react';
-import { Box } from '../../ui';
+import { Flex } from '../../ui';
 import { globalCss } from '../../stitches.config';
 import { RoundPlus } from '../../icons';
 
@@ -51,15 +51,9 @@ export const FloatingMenu = ({ editor }: FloatingMenuProps) => {
         return editor.isActive('paragraph') && empty && node.content.size === 0;
       }}
     >
-      <Box
-        as="button"
-        onClick={handleButtonClick}
-        css={{
-          display: 'flex',
-        }}
-      >
+      <Flex as="button" onClick={handleButtonClick}>
         <RoundPlus width={27} height={27} />
-      </Box>
+      </Flex>
     </TipTapFloatingMenu>
   );
 };

--- a/sigle/src/modules/editor/TipTapEditor.tsx
+++ b/sigle/src/modules/editor/TipTapEditor.tsx
@@ -180,7 +180,7 @@ export const TipTapEditor = ({}: TipTapEditorProps) => {
   return (
     <>
       {editor && <BubbleMenu editor={editor} />}
-      {/* {editor && <FloatingMenu editor={editor} />} */}
+      {editor && <FloatingMenu editor={editor} />}
 
       <StyledEditorContent editor={editor} />
 


### PR DESCRIPTION
Create an inline menu displayed on the left side when you create a new empty paragraph. Clicking on the + icon should open the slash menu.

![Screenshot 2022-01-24 at 17 43 31](https://user-images.githubusercontent.com/5749437/150826074-34a3602a-41d2-482d-ba6c-4f9d8f3c6b4d.png)

