### PR TITLE
feat: add GIF support to editor

### DIFF
--- a/sigle/src/modules/editor/components/SlateEditor.tsx
+++ b/sigle/src/modules/editor/components/SlateEditor.tsx
@@ -205,10 +205,10 @@ export const SlateEditor = ({
       );
 
       reader.addEventListener('load', async () => {
+        // Resize the image client side for faster upload and to save storage space
         // We skip resizing gif as it's turning them as single image
         let blob: Blob | File = file;
         if (file.type !== 'image/gif') {
-          // resize the image for faster upload
           blob = await resizeImage(file, { maxWidth: 2000 });
         }
 

--- a/sigle/src/modules/editor/components/SlateEditor.tsx
+++ b/sigle/src/modules/editor/components/SlateEditor.tsx
@@ -205,8 +205,12 @@ export const SlateEditor = ({
       );
 
       reader.addEventListener('load', async () => {
-        // resize the image for faster upload
-        const blob = await resizeImage(file, { maxWidth: 2000 });
+        // We skip resizing gif as it's turning them as single image
+        let blob: Blob | File = file;
+        if (file.type !== 'image/gif') {
+          // resize the image for faster upload
+          blob = await resizeImage(file, { maxWidth: 2000 });
+        }
 
         const name = `photos/${story.id}/${id}-${file.name}`;
         const imageUrl = await storage.putFile(name, blob as any, {

--- a/sigle/src/modules/editor/components/SlateEditorSideMenu.tsx
+++ b/sigle/src/modules/editor/components/SlateEditorSideMenu.tsx
@@ -82,7 +82,7 @@ export const SlateEditorSideMenu = forwardRef(
           >
             <input
               type="file"
-              accept="image/jpeg, image/png"
+              accept="image/jpeg,image/png,image/gif"
               onChange={(event) =>
                 addImageToEditor(editor, event.target.files as any)
               }

--- a/sigle/src/modules/editor/components/SlateEditorToolbar.tsx
+++ b/sigle/src/modules/editor/components/SlateEditorToolbar.tsx
@@ -215,7 +215,7 @@ export const SlateEditorToolbar = ({
         >
           <input
             type="file"
-            accept="image/jpeg, image/png"
+            accept="image/jpeg,image/png,image/gif"
             onChange={(event) =>
               addImageToEditor(editor, event.target.files as any)
             }


### PR DESCRIPTION
Add GIF support to the current slate Editor. Will be migrated to the new TipTap editor too once I add support of images there.

Fixes https://github.com/pradel/sigle/issues/109